### PR TITLE
Feature/ung 949 anchoring token

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.ubirch</groupId>
+            <artifactId>ubirch-token-sdk</artifactId>
+            <version>0.6.5-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>com.ubirch.niomon</groupId>
             <artifactId>foundation</artifactId>
             <version>1.0.3-SNAPSHOT</version>

--- a/src/main/resources/application-base.conf
+++ b/src/main/resources/application-base.conf
@@ -82,5 +82,5 @@ token {
   audience: "https://niomon.dev.ubirch.com"
   tokenManager: token.issuer
   scopes: ["upp:anchor"],
-  secret: "judgDg3jaCDM-QwKFZpTiEcXnLdbbGEdzcO57/yoIVGOpixXfeKGLDdg="
+  secret: "baO4L74O4SZE-B7LqicyRUZPFcyn5NeypcB5L438bXuzaKMX2CrWFwtH9"
 }

--- a/src/main/resources/application-base.conf
+++ b/src/main/resources/application-base.conf
@@ -79,8 +79,8 @@ token {
   env: dev
   tokenPublicKey: "2e09fc73de8b067c4c38292e8d683ed3abaef220c9b8a6b85935a055359139a70f17b2e76543518a113fba84863db6060bb0224fc45104ca0ac8a8279b0d744a"
   issuer: "https://token."${token.env}".ubirch.com"
-  audience: "https://verify."${token.env}".ubirch.com"
+  audience: "https://niomon.dev.ubirch.com"
   tokenManager: token.issuer
-  scopes: ["thing:create"],
+  scopes: ["upp:anchor"],
   secret: "judgDg3jaCDM-QwKFZpTiEcXnLdbbGEdzcO57/yoIVGOpixXfeKGLDdg="
 }

--- a/src/main/resources/application-base.conf
+++ b/src/main/resources/application-base.conf
@@ -79,7 +79,7 @@ token {
   env: dev
   tokenPublicKey: "2e09fc73de8b067c4c38292e8d683ed3abaef220c9b8a6b85935a055359139a70f17b2e76543518a113fba84863db6060bb0224fc45104ca0ac8a8279b0d744a"
   issuer: "https://token."${token.env}".ubirch.com"
-  audience: "https://niomon.dev.ubirch.com"
+  audience: "https://niomon."${token.env}".ubirch.com"
   tokenManager: token.issuer
   scopes: ["upp:anchor"],
   secret: "baO4L74O4SZE-B7LqicyRUZPFcyn5NeypcB5L438bXuzaKMX2CrWFwtH9"

--- a/src/main/resources/application-base.conf
+++ b/src/main/resources/application-base.conf
@@ -74,3 +74,13 @@ redisson {
     }
   ]
 }
+
+token {
+  env: dev
+  tokenPublicKey: "2e09fc73de8b067c4c38292e8d683ed3abaef220c9b8a6b85935a055359139a70f17b2e76543518a113fba84863db6060bb0224fc45104ca0ac8a8279b0d744a"
+  issuer: "https://token."${token.env}".ubirch.com"
+  audience: "https://verify."${token.env}".ubirch.com"
+  tokenManager: token.issuer
+  scopes: ["thing:create"],
+  secret: "judgDg3jaCDM-QwKFZpTiEcXnLdbbGEdzcO57/yoIVGOpixXfeKGLDdg="
+}

--- a/src/main/resources/application-docker.conf
+++ b/src/main/resources/application-docker.conf
@@ -1,1 +1,7 @@
 include "application-base.conf"
+
+token {
+  env: ${ENV}
+  tokenPublicKey = ${TOKEN_SERVICE_PUBLIC_KEY}
+  secret = ${TOKEN_CLIENT_SECRET}
+}

--- a/src/main/scala/com/ubirch/configurationinjector/MultiEnricher.scala
+++ b/src/main/scala/com/ubirch/configurationinjector/MultiEnricher.scala
@@ -5,12 +5,15 @@ import org.apache.kafka.clients.consumer.ConsumerRecord
 
 /** Enricher that dispatches between the cumulocity- and keycloak-based enrichers */
 class MultiEnricher(context: NioMicroservice.Context) extends Enricher {
+
   val cumulocityBasedEnricher = new CumulocityBasedEnricher(context)
   val ubirchKeycloakEnricher = new UbirchKeycloakEnricher(context)
+  val ubirchTokenEnricher = new UbirchTokenEnricher()
 
   override def enrich(record: ConsumerRecord[String, MessageEnvelope]): ConsumerRecord[String, MessageEnvelope] = {
     record.findHeader("X-Ubirch-Auth-Type") match {
       case Some("keycloak") | Some("ubirch") => ubirchKeycloakEnricher.enrich(record)
+      case Some("ubirch-token") => ubirchTokenEnricher.enrich(record)
       case _ => cumulocityBasedEnricher.enrich(record)
     }
   }

--- a/src/main/scala/com/ubirch/configurationinjector/UbirchEnricher.scala
+++ b/src/main/scala/com/ubirch/configurationinjector/UbirchEnricher.scala
@@ -1,0 +1,16 @@
+package com.ubirch.configurationinjector
+
+import com.typesafe.scalalogging.LazyLogging
+
+trait UbirchEnricher extends Enricher with LazyLogging {
+
+  case class DeviceInfo(hwDeviceId: String, description: String, customerId: String)
+
+  def xcode(reason: Throwable): Int = reason match {
+    case _: NoSuchElementException => 1000
+    case _: IllegalArgumentException => 2000
+    case _: RuntimeException => 4000
+    case _ => 5000
+  }
+
+}

--- a/src/main/scala/com/ubirch/configurationinjector/UbirchTokenEnricher.scala
+++ b/src/main/scala/com/ubirch/configurationinjector/UbirchTokenEnricher.scala
@@ -1,0 +1,51 @@
+package com.ubirch.configurationinjector
+
+import java.util.UUID
+
+import com.ubirch.defaults.TokenApi
+import com.ubirch.kafka.MessageEnvelope
+import com.ubirch.niomon.base.NioMicroservice.WithHttpStatus
+import net.logstash.logback.argument.StructuredArguments.v
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.json4s.Formats
+import org.json4s._
+import org.json4s.JsonAST.JObject
+
+class UbirchTokenEnricher extends UbirchEnricher {
+
+  implicit val formats: Formats = com.ubirch.kafka.formats
+
+  override def enrich(record: ConsumerRecord[String, MessageEnvelope]): ConsumerRecord[String, MessageEnvelope] = {
+
+    val enrichment: Either[Throwable, JObject] = for {
+      token <- record
+        .findHeader("X-Ubirch-DeviceInfo-Token")
+        .toRight(new NoSuchElementException("No X-Ubirch-DeviceInfo-Token header present"))
+
+      hardwareId <- record.findHeader("X-Ubirch-Hardware-Id")
+        .map(UUID.fromString)
+        .toRight(new NoSuchElementException("missing X-Ubirch-Hardware-Id header"))
+
+      claims <- TokenApi.decodeAndVerify(token).toEither
+      clientId <- claims.isSubjectUUID.toEither
+
+      diObj <- scala.util.Try(DeviceInfo(hardwareId.toString, "", clientId.toString))
+        .map(Extraction.decompose)
+        .map(_.asInstanceOf[JObject])
+        .recover {
+          case _: Exception => throw new IllegalArgumentException("claims could not be materialized")
+        }.toEither
+
+    } yield diObj
+
+    enrichment.fold({ error =>
+      val requestId = record.requestIdHeader().orNull
+      logger.error(s"error while trying to enrich [{}]", v("requestId", requestId), error)
+      throw WithHttpStatus(400, error, Option(xcode(error)))
+    }, { extraData =>
+      val newContext = record.value().context.merge(extraData)
+      record.copy(value = record.value().copy(context = newContext))
+    })
+  }
+
+}

--- a/src/test/scala/com/ubirch/configurationinjector/UbirchTokenEnricherTest.scala
+++ b/src/test/scala/com/ubirch/configurationinjector/UbirchTokenEnricherTest.scala
@@ -1,0 +1,68 @@
+package com.ubirch.configurationinjector
+
+import java.util.UUID
+
+import com.ubirch.kafka.MessageEnvelope
+import com.ubirch.niomon.base.NioMicroservice.WithHttpStatus
+import com.ubirch.protocol.ProtocolMessage
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.scalatest.{FlatSpec, Matchers}
+import org.json4s._
+
+class UbirchTokenEnricherTest extends FlatSpec with Matchers {
+
+  "UbirchTokenEnricher" should "verify correctly" in {
+
+    val tokenEnricher =  new UbirchTokenEnricher
+
+    val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2VuLmRldi51YmlyY2guY29tIiwic3ViIjoiOTYzOTk1ZWQtY2UxMi00ZWE1LTg5ZGMtYjE4MTcwMWQxZDdiIiwiYXVkIjpbImh0dHBzOi8vYXBpLmNvbnNvbGUuZGV2LnViaXJjaC5jb20iLCJodHRwczovL25pb21vbi5kZXYudWJpcmNoLmNvbSIsImh0dHBzOi8vdmVyaWZ5LmRldi51YmlyY2guY29tIl0sImV4cCI6NzkyODAwMDg1MiwiaWF0IjoxNjE2NjEwNDUyLCJqdGkiOiJmMTMwNmJhYi0zODIzLTRkYWUtYTIxZS03ZmJiMDFiNmI5ODciLCJzY3AiOlsidGhpbmc6Y3JlYXRlIiwidXBwOmFuY2hvciIsInVwcDp2ZXJpZnkiXSwicHVyIjoiS2luZyBEdWRlIC0gQ29uY2VydCIsInRncCI6W10sInRpZCI6WyI4NDBiN2UyMS0wM2U5LTRkZTctYmIzMS0wYjk1MjRmM2I1MDAiXSwib3JkIjpbImh0dHA6Ly92ZXJpZmljYXRpb24uZGV2LnViaXJjaC5jb20iXX0.0-CA-dhgbRjzWbCjX1e3B08bSiPDbeZfBDb85uJPf3rEuNNH6MeVk0RKt2MVq7DMYco_c5Wolf09wdKX8kRrIA"
+
+    val record = new ConsumerRecord[String, MessageEnvelope]("foo", 0, 0, "bar",
+      MessageEnvelope(new ProtocolMessage(28, UUID.fromString("840b7e21-03e9-4de7-bb31-0b9524f3b500"), 0, null)))
+      .withExtraHeaders("X-Ubirch-DeviceInfo-Token" -> token)
+      .withExtraHeaders("X-Ubirch-Hardware-Id" -> "840b7e21-03e9-4de7-bb31-0b9524f3b500")
+
+    lazy val enriched = tokenEnricher.enrich(record)
+
+    assert(enriched.isInstanceOf[ConsumerRecord[String, MessageEnvelope]])
+
+    val obj = for{
+      JObject(child) <- enriched.value().context
+      JField("hwDeviceId", JString("840b7e21-03e9-4de7-bb31-0b9524f3b500")) <- child
+      JField("description", JString("")) <- child
+      JField("customerId", JString("963995ed-ce12-4ea5-89dc-b181701d1d7b")) <- child
+    } yield true
+
+
+    assert(obj == List(true))
+
+  }
+
+  it should "verify fail if hardwareId doesn't match" in {
+
+    val tokenEnricher =  new UbirchTokenEnricher
+
+    val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2VuLmRldi51YmlyY2guY29tIiwic3ViIjoiOTYzOTk1ZWQtY2UxMi00ZWE1LTg5ZGMtYjE4MTcwMWQxZDdiIiwiYXVkIjpbImh0dHBzOi8vYXBpLmNvbnNvbGUuZGV2LnViaXJjaC5jb20iLCJodHRwczovL25pb21vbi5kZXYudWJpcmNoLmNvbSIsImh0dHBzOi8vdmVyaWZ5LmRldi51YmlyY2guY29tIl0sImV4cCI6NzkyODAwMDg1MiwiaWF0IjoxNjE2NjEwNDUyLCJqdGkiOiJmMTMwNmJhYi0zODIzLTRkYWUtYTIxZS03ZmJiMDFiNmI5ODciLCJzY3AiOlsidGhpbmc6Y3JlYXRlIiwidXBwOmFuY2hvciIsInVwcDp2ZXJpZnkiXSwicHVyIjoiS2luZyBEdWRlIC0gQ29uY2VydCIsInRncCI6W10sInRpZCI6WyI4NDBiN2UyMS0wM2U5LTRkZTctYmIzMS0wYjk1MjRmM2I1MDAiXSwib3JkIjpbImh0dHA6Ly92ZXJpZmljYXRpb24uZGV2LnViaXJjaC5jb20iXX0.0-CA-dhgbRjzWbCjX1e3B08bSiPDbeZfBDb85uJPf3rEuNNH6MeVk0RKt2MVq7DMYco_c5Wolf09wdKX8kRrIA"
+
+    val record = new ConsumerRecord[String, MessageEnvelope]("foo", 0, 0, "bar",
+      MessageEnvelope(new ProtocolMessage(28, UUID.fromString("1b4bc7bf-d333-4fc5-97c7-93c16fc18970"), 0, null)))
+      .withExtraHeaders("X-Ubirch-DeviceInfo-Token" -> token)
+      .withExtraHeaders("X-Ubirch-Hardware-Id" -> "1b4bc7bf-d333-4fc5-97c7-93c16fc18970")
+
+    assertThrows[WithHttpStatus](tokenEnricher.enrich(record))
+
+  }
+
+  it should "verify fail if token not found" in {
+
+    val tokenEnricher =  new UbirchTokenEnricher
+
+    val record = new ConsumerRecord[String, MessageEnvelope]("foo", 0, 0, "bar",
+      MessageEnvelope(new ProtocolMessage(28, UUID.fromString("1b4bc7bf-d333-4fc5-97c7-93c16fc18970"), 0, null)))
+      .withExtraHeaders("X-Ubirch-Hardware-Id" -> "1b4bc7bf-d333-4fc5-97c7-93c16fc18970")
+
+    assertThrows[WithHttpStatus](tokenEnricher.enrich(record))
+
+  }
+
+}


### PR DESCRIPTION
This PR adds support to recognize Ubirch Tokens

Basically i added an extra auth type to the existing "X-Ubirch-Auth-Type" to perform token based enrichment/auth

An nice thing here is that the enricher doesn't do any external call for the ubirch token as already validate in the auth, it only extracts the needed info and sets it as context for the later stages

These changes make use of the ubirch token sdk that allows faster integration